### PR TITLE
quick prototype of sampler op using OMP

### DIFF
--- a/python/dgl/contrib/sampling/__init__.py
+++ b/python/dgl/contrib/sampling/__init__.py
@@ -1,4 +1,4 @@
-from .sampler import NeighborSampler, LayerSampler, EdgeSampler, sample_neighbors
+from .sampler import NeighborSampler, LayerSampler, EdgeSampler, sample_neighbors, compact_graphs
 from .randomwalk import *
 from .dis_sampler import SamplerSender, SamplerReceiver
 from .dis_sampler import SamplerPool

--- a/python/dgl/contrib/sampling/__init__.py
+++ b/python/dgl/contrib/sampling/__init__.py
@@ -1,4 +1,4 @@
-from .sampler import NeighborSampler, LayerSampler, EdgeSampler
+from .sampler import NeighborSampler, LayerSampler, EdgeSampler, sample_neighbors
 from .randomwalk import *
 from .dis_sampler import SamplerSender, SamplerReceiver
 from .dis_sampler import SamplerPool

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -11,6 +11,7 @@ from ..._ffi.object import register_object, ObjectBase
 from ..._ffi.ndarray import empty
 from ... import utils
 from ...nodeflow import NodeFlow
+from ...graph import DGLGraph
 from ... import backend as F
 from ... import subgraph
 
@@ -785,5 +786,18 @@ def create_full_nodeflow(g, num_layers, add_self_loop=False):
     sampler = NeighborSampler(g, batch_size, expand_factor,
         num_layers, add_self_loop=add_self_loop)
     return next(iter(sampler))
+
+def sample_neighbors(g, nodes, fanout, edge_dir='in', p=None, replace=True):
+    nodes = utils.toindex(nodes)
+    if p is None:
+        p = F.tensor([], F.float32)
+    gidx = _CAPI_NeighborSamplingNew(
+        g._graph,
+        nodes.todgltensor(),
+        int(fanout),
+        edge_dir,
+        F.zerocopy_to_dgl_ndarray(p),
+        replace)
+    return DGLGraph(gidx)
 
 _init_api('dgl.sampling', __name__)

--- a/python/dgl/contrib/sampling/sampler.py
+++ b/python/dgl/contrib/sampling/sampler.py
@@ -800,4 +800,9 @@ def sample_neighbors(g, nodes, fanout, edge_dir='in', p=None, replace=True):
         replace)
     return DGLGraph(gidx)
 
+def compact_graphs(graphs):
+    in_gidx = [g._graph for g in graphs]
+    out_gidx = _CAPI_CompactGraphs(in_gidx)
+    return [DGLGraph(gidx) for gidx in out_gidx]
+
 _init_api('dgl.sampling', __name__)

--- a/src/graph/sampler_new.cc
+++ b/src/graph/sampler_new.cc
@@ -1,0 +1,106 @@
+#include <dgl/immutable_graph.h>
+#include <dgl/runtime/container.h>
+#include <dgl/packed_func_ext.h>
+#include <dgl/random.h>
+#include <dmlc/omp.h>
+
+#include "../c_api_common.h"
+#include "../array/common.h"  // for ATEN_FLOAT_TYPE_SWITCH
+
+using namespace dgl::runtime;
+
+namespace dgl {
+
+GraphPtr TestSampleImpl(ImmutableGraphPtr g, IdArray seed_nodes, int64_t fanout, std::string edge_dir) {
+  const dgl_id_t* nids = static_cast<const dgl_id_t*>(seed_nodes->data);
+  const int64_t L = seed_nodes->shape[0];
+
+  aten::CSRMatrix csr = (edge_dir == "in")? g->GetInCSR()->ToCSRMatrix() : g->GetOutCSR()->ToCSRMatrix();
+  const int64_t* indptr_data = static_cast<const int64_t*>(csr.indptr->data);
+  const int64_t* indices_data = static_cast<const int64_t*>(csr.indices->data);
+
+  IdArray rstsrc = aten::NewIdArray(fanout * L);
+  IdArray rstdst = aten::NewIdArray(fanout * L);
+  dgl_id_t* rstsrcdata = static_cast<dgl_id_t*>(rstsrc->data);
+  dgl_id_t* rstdstdata = static_cast<dgl_id_t*>(rstdst->data);
+
+#pragma omp parallel for
+  for (int64_t i = 0; i < L; ++i) {
+    const dgl_id_t nid = nids[i];
+    const int64_t off = indptr_data[nid];
+    const int64_t len = indptr_data[nid + 1] - off;
+    for (int64_t j = 0; j < fanout; ++j) {
+      rstsrcdata[i * fanout + j] = indices_data[off + RandomEngine::ThreadLocal()->RandInt(len)];
+      rstdstdata[i * fanout + j] = nid;
+    }
+  }
+
+  return ImmutableGraph::CreateFromCOO(g->NumVertices(), rstsrc, rstdst);
+}
+
+DGL_REGISTER_GLOBAL("sampling._CAPI_NeighborSamplingNew")
+.set_body([] (DGLArgs args, DGLRetValue* rv) {
+    // arguments
+    const GraphRef g = args[0];
+    const IdArray seed_nodes = args[1];
+    const int64_t fanout = args[2];
+    const std::string edge_dir = args[3];
+    const NDArray probability = args[4];
+    const bool replace = args[5];
+
+    auto gptr = std::dynamic_pointer_cast<ImmutableGraph>(g.sptr());
+    CHECK(gptr) << "sampling isn't implemented in mutable graph";
+
+    CHECK(aten::IsValidIdArray(seed_nodes));
+    CHECK_EQ(seed_nodes->ctx.device_type, kDLCPU)
+      << "NeighborSampler only support CPU sampling";
+
+    CHECK(probability->dtype.code == kDLFloat)
+      << "transition probability must be float";
+    CHECK(probability->ndim == 1)
+      << "transition probability must be a 1-dimensional vector";
+    CHECK_EQ(probability->ctx.device_type, kDLCPU)
+      << "NeighborSampling only support CPU sampling";
+
+    /*int L = 1000;
+    std::vector<int> vec(L, 0);
+#pragma omp parallel for
+    for (int64_t i = 0; i < L; ++i) {
+      for (int64_t j = 0; j < 1000000; ++j) {
+        for (int64_t jj = 0; jj < 10000; ++j) {
+          vec[i] += j;
+        }
+      }
+    }
+
+    for (int64_t i = L - 1; i > L - 10; --i) {
+      LOG(INFO) << vec[i];
+    }*/
+
+    GraphPtr ret;
+
+    ATEN_FLOAT_TYPE_SWITCH(
+      probability->dtype,
+      FloatType,
+      "transition probability",
+      {
+        const FloatType *prob;
+
+        if (probability->ndim == 1 && probability->shape[0] == 0) {
+          prob = nullptr;
+        } else {
+          CHECK(probability->shape[0] == gptr->NumEdges())
+            << "transition probability must have same number of elements as edges";
+          CHECK(probability.IsContiguous())
+            << "transition probability must be contiguous tensor";
+          prob = static_cast<const FloatType *>(probability->data);
+        }
+
+        ret = TestSampleImpl(gptr, seed_nodes, fanout, edge_dir);
+
+    });
+
+    *rv = GraphRef(ret);
+  });
+
+}  // namespace dgl

--- a/t.py
+++ b/t.py
@@ -1,0 +1,43 @@
+import dgl
+from dgl.data import RedditDataset
+import torch as th
+import numpy as np
+from dgl.contrib.sampling import sample_neighbors, NeighborSampler
+import time
+
+data = RedditDataset(self_loop=True)
+train_nid = th.LongTensor(np.nonzero(data.train_mask)[0])
+g = dgl.DGLGraph(data.graph, readonly=True)
+print('Graph created')
+
+# try run
+f1 = sample_neighbors(g, train_nid[0:10], 2)
+print('Dry run finished')
+
+#print(train_nid[0:1000])
+
+##################### Test 1: Use the new subgraph sampling API ####################
+t = time.time()
+for i in range(100):
+    seed_nodes = train_nid[i*1000:(i+1)*1000]
+    f1 = sample_neighbors(g, seed_nodes, 10)
+    u, _ = f1.edges(form='uv')
+    f2 = sample_neighbors(g, th.unique(u), 10)
+    #print(i, f2.number_of_edges())
+print('Time:', time.time() - t)
+
+##################### Test 2: Use the old sampler data loader ####################
+sampler = NeighborSampler(
+        g, 1000, 10,
+        neighbor_type='in',
+        shuffle=False,
+        num_hops=2,
+        seed_nodes=train_nid,
+        num_workers=4)
+
+t = time.time()
+for i, nf in enumerate(sampler):
+    #print(i, len(nf.block_eid(0)))
+    if i == 99:
+        break
+print('Time:', time.time() - t)

--- a/t.py
+++ b/t.py
@@ -2,7 +2,7 @@ import dgl
 from dgl.data import RedditDataset
 import torch as th
 import numpy as np
-from dgl.contrib.sampling import sample_neighbors, NeighborSampler
+from dgl.contrib.sampling import sample_neighbors, NeighborSampler, compact_graphs
 import time
 
 data = RedditDataset(self_loop=True)
@@ -23,7 +23,8 @@ for i in range(100):
     f1 = sample_neighbors(g, seed_nodes, 10)
     u, _ = f1.edges(form='uv')
     f2 = sample_neighbors(g, th.unique(u), 10)
-    #print(i, f2.number_of_edges())
+    f1, f2 = compact_graphs([f1, f2])
+    #print(i, f2.number_of_nodes(), f2.number_of_edges())
 print('Time:', time.time() - t)
 
 ##################### Test 2: Use the old sampler data loader ####################


### PR DESCRIPTION
Implement a quick prototype of neighbor sampler operator by a different parallel strategy. The old neighbor sampler loader lets each thread handles one batch (create one nodeflow). The new neighbor sampler uses the omp parallel for in the inner loop, so all threads cooperatively work on one subgraph. 

Although this is a super simplified implementation, the result is quite promising. On reddit graph, to generate 100 batches, the old neighbor sampler takes 16.6s while the new implementation takes only **0.47s**. Both tests are run on p3.16xlarge, with 8VCPU and with 4 worker threads.